### PR TITLE
fix(release): drop unsupported --provenance flag from changeset publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test-coverage": "vitest --run --coverage",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm run build && pnpm exec changeset publish --provenance",
+    "release": "pnpm run build && pnpm exec changeset publish",
     "check-types": "pnpm exec attw $(pnpm pack | tail -1) --profile=node16"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes the failing release job:

```
🦋  error Unknown flag for publish: --provenance
🦋  error Usage: changeset publish [--tag <name>] [--otp <code>] [--no-git-tag]
```

`changeset publish` only accepts `--tag` / `--otp` / `--no-git-tag`. `--provenance` is an `npm publish` flag, not a changesets one. It was present in the original `release` script and silently tolerated by older changesets, but the upgrade to `@changesets/cli` 2.31.0 made it a hard error.

```diff
- "release": "pnpm run build && pnpm exec changeset publish --provenance",
+ "release": "pnpm run build && pnpm exec changeset publish",
```

Provenance is still produced: `@eatsjobs/media-mock` is a public package published via OIDC trusted publishing (`id-token: write`), and npm generates provenance automatically in that setup — so no flag or `NPM_CONFIG_PROVENANCE` is needed.

## Notes

- The docs / `loadImage` crossOrigin / biome-override / defineProperty work landed separately in #46, so this PR contains only the one-line release-script fix.
- After merge, the release runs through changesets' normal version-PR → publish cycle; `changeset publish` will publish any pending version via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)